### PR TITLE
Move shebang to the first line

### DIFF
--- a/waydroid-session.sh
+++ b/waydroid-session.sh
@@ -1,9 +1,9 @@
+#!/bin/bash
+
 # weston --xwayland &
 # export WAYLAND_DISPLAY=wayland-1
 # sleep 2
 # waydroid show-full-ui &
-
-#!/bin/bash
 
 # Ensure the script is run from its directory
 cd "$(dirname "$0")"


### PR DESCRIPTION
Running `waydroid-session.sh` works fine from bash, but I was getting the following error when running `waydroid-session.sh` from a shortcut in the application menu:

```
Warning: Could not start program '/usr/bin/waydroid-session.sh' with arguments ''.

Warning: Child process set up failed: execve: Exec format error
```

Changing the shebang to be the very first line, as in this pull request, allows execve to use it properly. With this fix the shortcut to `waydroid-session.sh` works correctly and launches waydroid. relevant thread: https://discuss.kde.org/t/child-process-set-up-failed-execve-exec-format-error/15500 

This was tested on a Debian Trixie system with KDE Plasma 6.3.6, and the shortcut `/usr/share/applications/waydroid-session.desktop` being similar to that in readme but with terminal enabled for debugging:

```
[Desktop Entry]
Version=1.0
Type=Application
Name=Waydroid Session
Comment=Start Waydroid in a Weston session
Exec=/usr/bin/waydroid-session.sh
Icon=waydroid
Terminal=true
Categories=System;Emulator;
```

